### PR TITLE
chore: bump hyprgraphics to v0.5.0

### DIFF
--- a/specs/hyprgraphics.spec
+++ b/specs/hyprgraphics.spec
@@ -1,5 +1,5 @@
 Name:           hyprgraphics
-Version:        0.4.0
+.5.0
 Release:        %autorelease
 Summary:        Hyprland graphics / resource utilities
 


### PR DESCRIPTION
Automated bump for `hyprgraphics` spec.

- Current version: 0.4.0
- Upstream version: 0.5.0

This updates `specs/hyprgraphics.spec` when upstream moves ahead.