### PR TITLE
chore: bump hyprland-guiutils to v0.2.1

### DIFF
--- a/brood/hyprland-guiutils.spec
+++ b/brood/hyprland-guiutils.spec
@@ -1,5 +1,5 @@
 Name:           hyprland-guiutils
-Version:        0.2.0
+.2.1
 Release:        %autorelease
 Summary:        Hyprland GUI utilities (successor to hyprland-qtutils)
 


### PR DESCRIPTION
Automated bump for `hyprland-guiutils` spec.

- Current version: 0.2.0
- Upstream version: 0.2.1

This updates `brood/hyprland-guiutils.spec` when upstream moves ahead.