### PR TITLE
chore: bump hyprtoolkit to v0.5.1

### DIFF
--- a/brood/hyprtoolkit.spec
+++ b/brood/hyprtoolkit.spec
@@ -1,5 +1,5 @@
 Name:           hyprtoolkit
-Version:        0.5.0
+Version:        0.5.10.5.0
 Release:        %autorelease
 Summary:        Modern C++ Wayland-native GUI toolkit
 


### PR DESCRIPTION
Automated bump for `hyprtoolkit` spec.

- Current version: 0.5.0
- Upstream version: 0.5.1

This updates `brood/hyprtoolkit.spec` when upstream moves ahead.