### PR TITLE
chore: bump hyprpaper to v0.8.1

### DIFF
--- a/brood/hyprpaper.spec
+++ b/brood/hyprpaper.spec
@@ -1,5 +1,5 @@
 Name:           hyprpaper
-Version:        0.8.0
+Version:        0.8.10.8.0
 Release:        %autorelease
 Summary:        Blazing fast Wayland wallpaper utility with IPC controls
 


### PR DESCRIPTION
Automated bump for `hyprpaper` spec.

- Current version: 0.8.0
- Upstream version: 0.8.1

This updates `brood/hyprpaper.spec` when upstream moves ahead.