### PR TITLE
chore: bump hyprlang to v0.6.8

### DIFF
--- a/specs/hyprlang.spec
+++ b/specs/hyprlang.spec
@@ -1,5 +1,5 @@
 Name:           hyprlang
-Version:        0.6.7
+Version:        0.6.8
 Release:        %autorelease
 Summary:        The official implementation library for the Hypr config language
 


### PR DESCRIPTION
Automated bump for `hyprlang` spec.

- Current version: 0.6.7
- Upstream version: 0.6.8

This updates `specs/hyprlang.spec` when upstream moves ahead.