### PR TITLE
chore: bump hyprland to v0.53.3

### DIFF
--- a/specs/hyprland.spec
+++ b/specs/hyprland.spec
@@ -1,5 +1,5 @@
 Name:           hyprland
-Version:        0.53.1
+Version:        0.53.3
 Release:        %autorelease
 Summary:        Dynamic tiling Wayland compositor
 License:        BSD-3-Clause


### PR DESCRIPTION
Automated bump for `hyprland` spec.

- Current version: 0.53.1
- Upstream version: 0.53.3

This updates `specs/hyprland.spec` when upstream moves ahead.