### PR TITLE
chore: bump hyprpaper to v0.8.3

### DIFF
--- a/brood/hyprpaper.spec
+++ b/brood/hyprpaper.spec
@@ -1,5 +1,5 @@
 Name:           hyprpaper
-Version:        0.8.2
+Version:        0.8.3
 Release:        %autorelease
 Summary:        Blazing fast Wayland wallpaper utility with IPC controls
 


### PR DESCRIPTION
Automated bump for `hyprpaper` spec.

- Current version: 0.8.2
- Upstream version: 0.8.3

This updates `brood/hyprpaper.spec` when upstream moves ahead.