### PR TITLE
chore: bump hyprlock to v0.9.4

### DIFF
--- a/brood/hyprlock.spec
+++ b/brood/hyprlock.spec
@@ -1,5 +1,5 @@
 Name:           hyprlock
-Version:        0.9.3
+Version:        0.9.4
 Release:        %autorelease
 Summary:        Hyprland's GPU-accelerated screen locking utility
 


### PR DESCRIPTION
Automated bump for `hyprlock` spec.

- Current version: 0.9.3
- Upstream version: 0.9.4

This updates `brood/hyprlock.spec` when upstream moves ahead.