### PR TITLE
chore: bump aquamarine to v0.11.0

### DIFF
--- a/specs/aquamarine.spec
+++ b/specs/aquamarine.spec
@@ -1,5 +1,5 @@
 Name:           aquamarine
-Version:        0.10.0
+Version:        0.11.0
 Release:        %autorelease
 Summary:        A very light linux rendering backend library
 


### PR DESCRIPTION
Automated bump for `aquamarine` spec.

- Current version: 0.10.0
- Upstream version: 0.11.0

This updates `specs/aquamarine.spec` when upstream moves ahead.