### PR TITLE
chore: bump hyprwayland-scanner to v0.4.6

### DIFF
--- a/specs/hyprwayland-scanner.spec
+++ b/specs/hyprwayland-scanner.spec
@@ -1,5 +1,5 @@
 Name:           hyprwayland-scanner
-Version:        0.4.5
+Version:        0.4.6
 Release:        %autorelease
 # Rebuilt: 2026-04-08
 Summary:        A Hyprland implementation of wayland-scanner, in and for C++


### PR DESCRIPTION
Automated bump for `hyprwayland-scanner` spec.

- Current version: 0.4.5
- Upstream version: 0.4.6

This updates `specs/hyprwayland-scanner.spec` when upstream moves ahead.