### PR TITLE
chore: bump hyprwire to v0.3.1

### DIFF
--- a/specs/hyprwire.spec
+++ b/specs/hyprwire.spec
@@ -1,5 +1,5 @@
 Name:           hyprwire
-Version:        0.3.0
+Version:        0.3.1
 Release:        %autorelease
 Summary:        Hyprland wire/IPC helper library
 


### PR DESCRIPTION
Automated bump for `hyprwire` spec.

- Current version: 0.3.0
- Upstream version: 0.3.1

This updates `specs/hyprwire.spec` when upstream moves ahead.