### PR TITLE
chore: bump xdg-desktop-portal-hyprland to v1.3.12

### DIFF
--- a/brood/xdg-desktop-portal-hyprland.spec
+++ b/brood/xdg-desktop-portal-hyprland.spec
@@ -1,5 +1,5 @@
 Name:           xdg-desktop-portal-hyprland
-Version:        1.3.11
+Version:        1.3.12
 Release:        %autorelease
 Summary:        XDG Desktop Portal backend for Hyprland
 


### PR DESCRIPTION
Automated bump for `xdg-desktop-portal-hyprland` spec.

- Current version: 1.3.11
- Upstream version: 1.3.12

This updates `brood/xdg-desktop-portal-hyprland.spec` when upstream moves ahead.