### PR TITLE
chore: bump hyprutils to v0.13.0

### DIFF
--- a/specs/hyprutils.spec
+++ b/specs/hyprutils.spec
@@ -1,5 +1,5 @@
 Name:           hyprutils
-Version:        0.12.0
+Version:        0.13.0
 Release:        %autorelease
 # Rebuilt: 2026-04-08
 Summary:        Hyprland utilities library used across the ecosystem


### PR DESCRIPTION
Automated bump for `hyprutils` spec.

- Current version: 0.12.0
- Upstream version: 0.13.0

This updates `specs/hyprutils.spec` when upstream moves ahead.