### PR TITLE
chore: bump hyprtoolkit to v0.5.4

### DIFF
--- a/brood/hyprtoolkit.spec
+++ b/brood/hyprtoolkit.spec
@@ -1,5 +1,5 @@
 Name:           hyprtoolkit
-Version:        0.5.3
+Version:        0.5.4
 Release:        %autorelease
 Summary:        Modern C++ Wayland-native GUI toolkit
 


### PR DESCRIPTION
Automated bump for `hyprtoolkit` spec.

- Current version: 0.5.3
- Upstream version: 0.5.4

This updates `brood/hyprtoolkit.spec` when upstream moves ahead.