### PR TITLE
chore: bump hyprpicker to v0.4.7

### DIFF
--- a/brood/hyprpicker.spec
+++ b/brood/hyprpicker.spec
@@ -1,5 +1,5 @@
 Name:           hyprpicker
-Version:        0.4.6
+Version:        0.4.7
 Release:        %autorelease
 # Rebuilt: 2026-05-04
 Summary:        A wlroots-compatible Wayland color picker that does not suck


### PR DESCRIPTION
Automated bump for `hyprpicker` spec.

- Current version: 0.4.6
- Upstream version: 0.4.7

This updates `brood/hyprpicker.spec` when upstream moves ahead.