### PR TITLE
chore: bump hyprutils to v0.13.1

### DIFF
--- a/specs/hyprutils.spec
+++ b/specs/hyprutils.spec
@@ -1,5 +1,5 @@
 Name:           hyprutils
-Version:        0.13.0
+Version:        0.13.1
 Release:        %autorelease
 # Rebuilt: 2026-05-04
 Summary:        Hyprland utilities library used across the ecosystem


### PR DESCRIPTION
Automated bump for `hyprutils` spec.

- Current version: 0.13.0
- Upstream version: 0.13.1

This updates `specs/hyprutils.spec` when upstream moves ahead.