### PR TITLE
chore: bump hyprland to v0.55.0

### DIFF
--- a/specs/hyprland.spec
+++ b/specs/hyprland.spec
@@ -1,5 +1,5 @@
 Name:           hyprland
-Version:        0.54.3
+Version:        0.55.0
 Release:        %autorelease
 # Rebuilt: 2026-05-04
 Summary:        Dynamic tiling Wayland compositor


### PR DESCRIPTION
Automated bump for `hyprland` spec.

- Current version: 0.54.3
- Upstream version: 0.55.0

This updates `specs/hyprland.spec` when upstream moves ahead.