### PR TITLE
chore: bump hyprland to v0.55.1

### DIFF
--- a/specs/hyprland.spec
+++ b/specs/hyprland.spec
@@ -1,5 +1,5 @@
 Name:           hyprland
-Version:        0.55.0
+Version:        0.55.1
 Release:        %autorelease
 # Rebuilt: 2026-05-04
 Summary:        Dynamic tiling Wayland compositor


### PR DESCRIPTION
Automated bump for `hyprland` spec.

- Current version: 0.55.0
- Upstream version: 0.55.1

This updates `specs/hyprland.spec` when upstream moves ahead.